### PR TITLE
Improved Logger API & EnvVar replacement

### DIFF
--- a/Sources/Helpers/NatriumYamlHelper.swift
+++ b/Sources/Helpers/NatriumYamlHelper.swift
@@ -321,7 +321,7 @@ extension NatriumYamlHelper {
                 Logger.fatalError("Error for key '\(object.key)'")
             }
 
-            yamlValue = _replaceEnvironmentVariable(yamlValue)
+            yamlValue = _replaceEnvironmentVariables(yamlValue)
             dictionary[object.key] = yamlValue
         }
 
@@ -351,18 +351,21 @@ extension NatriumYamlHelper {
         }
     }
 
-    private func _replaceEnvironmentVariable(_ yamlValue: Yaml) -> Yaml {
-        if yamlValue.stringValue.hasPrefix("#env(") && yamlValue.stringValue.count > 6 {
-            let startIndex = yamlValue.stringValue.index(yamlValue.stringValue.startIndex, offsetBy: 5)
-            let endIndex = yamlValue.stringValue.index(yamlValue.stringValue.endIndex, offsetBy: -1)
-            let key = String(yamlValue.stringValue[startIndex..<endIndex])
-            if let envValue = natrium.environmentVariables[key] {
-                return Yaml.string(envValue)
-            } else {
-                Logger.fatalError("Environment variable not available: '\(key)'")
+    private func _replaceEnvironmentVariables(_ yamlValue: Yaml) -> Yaml {
+        var result = yamlValue
+        let regex = "#env\\((\\w+)\\)"
+
+        while let range = result.stringValue.range(of: regex, options: .regularExpression) {
+            let envVarName = result.stringValue[range].replacingOccurrences(of: regex, with: "$1", options: .regularExpression)
+
+            guard let envVarValue = natrium.environmentVariables[envVarName] else {
+                Logger.fatalError("Environment variable not available: '\(envVarName)'")
             }
+
+            result = Yaml.string(result.stringValue.replacingCharacters(in: range, with: envVarValue))
         }
-        return yamlValue
+
+        return result
     }
 
     fileprivate func _logDictionary(_ dic: [NatriumKey: Yaml]) {

--- a/Sources/Helpers/NatriumYamlHelper.swift
+++ b/Sources/Helpers/NatriumYamlHelper.swift
@@ -29,7 +29,6 @@ class NatriumYamlHelper {
             Logger.insets += 1
             guard let contents = File(path: natrium.yamlFile).contents else {
                 Logger.fatalError("Error reading \(natrium.yamlFile)")
-                return
             }
             yaml = try Yaml.load(contents)
 
@@ -161,7 +160,6 @@ extension NatriumYamlHelper {
         let environments = yaml["environments"].array?.compactMap { $0.string } ?? []
         if (environments.filter { $0 == self.natrium.environment }).isEmpty {
             Logger.fatalError("Environment '\(self.natrium.environment)' not available.")
-            return
         }
         for environment in environments {
             Logger.log(" - \(environment)")

--- a/Sources/Logger.swift
+++ b/Sources/Logger.swift
@@ -75,9 +75,8 @@ class Logger {
             print("Error: \(error)")
         }
     }
-    
-    @discardableResult
-    static func fatalError(_ line: String) -> String {
+
+    static func fatalError(_ line: String) -> Never {
         insets = 0
         if !shouldPrint {
             let currentDirectory = FileManager.default.currentDirectoryPath

--- a/Sources/Natrium.swift
+++ b/Sources/Natrium.swift
@@ -98,7 +98,6 @@ class Natrium {
 
         guard let xcodeProjectPath = Dir(path: projectDir).glob("*.xcodeproj").first?.path else {
             Logger.fatalError("Cannot find xcodeproj in folder '\(projectDir)'")
-            return
         }
         self.xcodeProjectPath = xcodeProjectPath
         _getXcodeProject()
@@ -140,12 +139,10 @@ extension Natrium {
             xcProjectFile = try XCProjectFile(xcodeprojURL: xcodeproj)
         } catch let error {
             Logger.fatalError("\(error)")
-            return
         }
 
         guard let target = (xcProjectFile.project.targets.first { $0.name == self.target }) else {
             Logger.fatalError("Cannot find target '\(self.target)' in '\(xcodeProjectPath ?? "")'")
-            return
         }
 
         self.configurations = target.buildConfigurationList.buildConfigurations.map { $0.name }
@@ -156,12 +153,10 @@ extension Natrium {
         guard let buildConfiguration = (xcTarget.buildConfigurationList.buildConfigurations
             .first { $0.name == self.configuration }) else {
                 Logger.fatalError("Cannot find configuration '\(self.configuration)' in '\(xcodeProjectPath ?? "")'")
-                return
         }
 
         guard let infoPlist = buildConfiguration.buildSettings?["INFOPLIST_FILE"] as? String else {
             Logger.fatalError("Cannot find INFOPLIST_FILE in '\(String(describing: xcodeProjectPath))'")
-            return
         }
 
         infoPlistPath = _replaceSettingsReferences(infoPlist)

--- a/Sources/Parsers/LaunchScreenStoryboardParser.swift
+++ b/Sources/Parsers/LaunchScreenStoryboardParser.swift
@@ -56,16 +56,13 @@ class LaunchScreenStoryboardParser: Parser {
 
         if pathFile == nil {
             Logger.fatalError("Missing 'path' parameter for 'launch_screen_versioning' key")
-            return
         }
 
         if labelName.isEmpty {
             Logger.fatalError("Missing 'labelName' parameter for 'launch_screen_versioning' key")
-            return
         }
         if !pathFile!.isExisting {
             Logger.fatalError("'\(pathFile!.path)' does not exist")
-            return
         }
         _run(labelName: labelName, pathFile: pathFile)
     }

--- a/Sources/Parsers/PlistParser.swift
+++ b/Sources/Parsers/PlistParser.swift
@@ -32,7 +32,6 @@ class PlistParser: Parser {
     func parse(_ yaml: [NatriumKey: Yaml]) {
         if !File(path: filePath).isExisting {
             Logger.fatalError("\(filePath!) does not exist")
-            return
         }
         for object in yaml {
             PlistHelper.write(value: object.value.stringValue, for: object.key.string, in: filePath)

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -50,7 +50,6 @@ if let projectDir = dic["PROJECT_DIR"], let targetName = dic["TARGET_NAME"], let
     Logger.shouldPrint = false
     if args.isEmpty {
         Logger.fatalError("Missing environment argument")
-        exit(EX_USAGE)
     }
     let environment = args[1]
 


### PR DESCRIPTION
- `Login.fatalError` never returns
- Done replacement of all `#env(VAR)` in strings, so now it supports things like: 
    ```yaml
    PR: "PR: #env(PR_NUMBER)-#env(PR_BRANCH)"
    ```